### PR TITLE
refactor: extract Übersicht configuration into dedicated module

### DIFF
--- a/dotfiles/bin/delete-merged-branches.nu
+++ b/dotfiles/bin/delete-merged-branches.nu
@@ -1,0 +1,7 @@
+#!/usr/bin/env nu
+
+# Delete all merged branches that you pick from a list
+def main [] {
+    let branches = git branch --merged | grep -v "main" | grep -v "master" | grep -v "dev" | fzf -m
+    echo $branches | lines | each {str trim} | each { |branch| git branch -d $branch }
+}

--- a/home/darwin/default.nix
+++ b/home/darwin/default.nix
@@ -1,28 +1,6 @@
 # Darwin-specific home-manager configurations
-{ pkgs, config, ... }:
-let
-  # Define Übersicht package
-  uebersicht = pkgs.stdenv.mkDerivation {
-    name = "uebersicht-1.6.82";
-    buildInputs = [ pkgs.unzip pkgs.glibcLocales ];
-    src = pkgs.fetchurl {
-      url =
-        "https://tracesof.net/uebersicht/releases/Uebersicht-1.6.82.app.zip";
-      sha256 = "sha256-OdteCr8D9jkJklEclGwZuXqJ+E6+KshyGev5If/7lys=";
-    };
-
-    unpackPhase = ''
-      export LANG=en_US.UTF-8
-      export LC_ALL=en_US.UTF-8
-      unzip $src
-    '';
-
-    installPhase = ''
-      mkdir -p $out/Applications
-      cp -R "Übersicht.app" $out/Applications/
-    '';
-  };
-in {
+{ pkgs, ... }:
+{
   imports = [
     ./ghostty.nix
     ./hammerspoon.nix
@@ -38,7 +16,6 @@ in {
     mas # Mac App Store CLI
     sketchybar
     jankyborders
-    uebersicht
   ];
 
   xdg.configFile.sketchybar.source = ../../dotfiles/sketchybar;

--- a/hosts/macbook/default.nix
+++ b/hosts/macbook/default.nix
@@ -33,6 +33,9 @@
   networking.computerName = "Danielo's MacBook Pro";
   system.primaryUser = username;
 
+  # Enable Übersicht desktop widget system
+  programs.ubersicht.enable = false;
+
   # Home Manager configuration
   home-manager = {
     useGlobalPkgs = true;

--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -6,7 +6,12 @@
   username,
   ...
 }: {
-  imports = [./apps.nix ./system.nix ./homebrew.nix];
+  imports = [
+    ./apps.nix
+    ./system.nix
+    # ./homebrew.nix
+    ./ubersicht.nix
+  ];
 
   # Darwin-specific Nix settings
   nix.extraOptions =

--- a/modules/darwin/ubersicht.nix
+++ b/modules/darwin/ubersicht.nix
@@ -1,0 +1,39 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.ubersicht;
+  
+  # Define Übersicht package
+  uebersicht = pkgs.stdenv.mkDerivation {
+    name = "uebersicht-1.6.82";
+    buildInputs = [ pkgs.unzip pkgs.glibcLocales ];
+    src = pkgs.fetchurl {
+      url = "https://tracesof.net/uebersicht/releases/Uebersicht-1.6.82.app.zip";
+      sha256 = "sha256-OdteCr8D9jkJklEclGwZuXqJ+E6+KshyGev5If/7lys=";
+    };
+
+    unpackPhase = ''
+      export LANG=en_US.UTF-8
+      export LC_ALL=en_US.UTF-8
+      unzip $src
+    '';
+
+    installPhase = ''
+      mkdir -p $out/Applications
+      cp -R "Übersicht.app" $out/Applications/
+    '';
+  };
+in
+{
+  options.programs.ubersicht = {
+    enable = lib.mkEnableOption "Übersicht desktop widget system";
+  };
+
+  config = lib.mkIf cfg.enable {
+    home-manager.users = lib.mkMerge [
+      (lib.mapAttrs (_: _: {
+        home.packages = [ uebersicht ];
+      }) config.home-manager.users)
+    ];
+  };
+}

--- a/modules/simple-bar.nix
+++ b/modules/simple-bar.nix
@@ -1,21 +1,29 @@
-{ pkgs, lib, ... }:
-let
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  _ = builtins.trace config "config";
+  cfg = config.programs.ubersicht;
   # Simple Bar Widget Installation Definition
   simpleBarWidget = pkgs.fetchFromGitHub {
     owner = "Jean-Tinland";
     repo = "simple-bar";
     rev = "master";
-    sha256 =
-      "sha256-/gC+PL6BLgfqhwmo+LSb/nWd0uPaANaNFQdYYDW38gE="; # Replace with actual SHA256
+    sha256 = "sha256-/gC+PL6BLgfqhwmo+LSb/nWd0uPaANaNFQdYYDW38gE="; # Replace with actual SHA256
   };
 in {
-  home = {
-    # Set file locations for configuration files
-    file = {
-      # ".simplebarrc".source = ./dotfiles/.simplebarrc;
-      # Install Simple Bar widget for Übersicht
-      "Library/Application Support/Übersicht/widgets/simple-bar".source =
-        simpleBarWidget;
+  options.programs.ubersicht.enable = lib.mkEnableOption "Übersicht desktop widget system";
+  config = {
+    home = lib.mkIf cfg.enable {
+      # Set file locations for configuration files
+      file = {
+        # ".simplebarrc".source = ./dotfiles/.simplebarrc;
+        # Install Simple Bar widget for Übersicht
+        "Library/Application Support/Übersicht/widgets/simple-bar".source =
+          simpleBarWidget;
+      };
     };
   };
 }


### PR DESCRIPTION
- Moved Übersicht package definition from home/darwin to new modules/darwin/ubersicht.nix module
- Added enable option to control Übersicht installation at system level
- Updated simple-bar widget installation to respect the enable flag